### PR TITLE
fix #3 -- do not treat flags with = as environment variables

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ module.exports = () => {
 
   /* load variables from command, and remove them from argv */
   let argv = process.argv.map((arg) => {
-    const match = arg.match(/(\w+)=('(.+)'|"(.+)"|(.+))/)
+    const match = arg.match(/^(?!-)(\w+)=('(.+)'|"(.+)"|(.+))/)
     if (match) {
       customEnv[match[1]] = match[3] || match[4] || match[5]
     } else {


### PR DESCRIPTION
Note that this will still propagate `VAR=VAL` as an environment variable, but not `-VAR=VAL` or `--VAR=VAL`.